### PR TITLE
Fix structure of package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
         "npm-force-resolutions": "^0.0.10",
         "snowpack": "^3.8.8",
         "typescript": "^4.3.5"
+      },
+      "engines": {
+        "node": "14.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "@inrupt/solid-client-authn-browser": "^1.11.0",
     "@inrupt/vocab-common-rdf": "^1.0.0",
     "preact": "^10.5.14",
-    "wouter-preact": "^2.7.4",
-    ""
+    "wouter-preact": "^2.7.4"
   },
   "devDependencies": {
     "@snowpack/plugin-typescript": "^1.2.1",


### PR DESCRIPTION
The current `package.json` contains an invalid blank line, which prevents the application from being compiling.
This patch removes that line; it also contains the updated `package-lock.json` (not sure if it should be included or not).